### PR TITLE
update chapter endings' dogs.js array export with working image URLs

### DIFF
--- a/chapter-2-end/src/data/dogs.js
+++ b/chapter-2-end/src/data/dogs.js
@@ -1,42 +1,42 @@
-export default [
-  {
-    name: 'Max',
-    breed: 'husky',
-    img: 'https://dog.ceo/api/img/husky/n02110185_1469.jpg',
-  },
-  {
-    name: 'Rusty',
-    breed: 'shiba',
-    img: 'https://dog.ceo/api/img/shiba/shiba-13.jpg',
-  },
-  {
-    name: 'Rocco',
-    breed: 'boxer',
-    img: 'https://dog.ceo/api/img/boxer/n02108089_14112.jpg',
-  },
-  {
-    name: 'Zoey',
-    breed: 'beagle',
-    img: 'https://dog.ceo/api/img/beagle/n02088364_11136.jpg',
-  },
-  {
-    name: 'Duke',
-    breed: 'doberman',
-    img: 'https://dog.ceo/api/img/doberman/n02107142_4653.jpg',
-  },
-  {
-    name: 'Lily',
-    breed: 'malamute',
-    img: 'https://dog.ceo/api/img/malamute/n02110063_1104.jpg',
-  },
-  {
-    name: 'Winston',
-    breed: 'pug',
-    img: 'https://dog.ceo/api/img/pug/n02110958_15626.jpg',
-  },
-  {
-    name: 'Angel',
-    breed: 'samoyed',
-    img: 'https://dog.ceo/api/img/samoyed/n02111889_4470.jpg',
-  },
+export const Dogs = [
+	{
+		name: 'Max',
+		breed: 'husky',
+		img: 'https://images.dog.ceo/breeds/husky/n02110185_1469.jpg',
+	},
+	{
+		name: 'Rusty',
+		breed: 'shiba',
+		img: 'https://images.dog.ceo/breeds/shiba/shiba-13.jpg',
+	},
+	{
+		name: 'Rocco',
+		breed: 'boxer',
+		img: 'https://images.dog.ceo/breeds/boxer/n02108089_14112.jpg',
+	},
+	{
+		name: 'Zoey',
+		breed: 'beagle',
+		img: 'https://images.dog.ceo/breeds/beagle/n02088364_11136.jpg',
+	},
+	{
+		name: 'Duke',
+		breed: 'doberman',
+		img: 'https://images.dog.ceo/breeds/doberman/n02107142_4653.jpg',
+	},
+	{
+		name: 'Lily',
+		breed: 'malamute',
+		img: 'https://images.dog.ceo/breeds/malamute/n02110063_1104.jpg',
+	},
+	{
+		name: 'Winston',
+		breed: 'pug',
+		img: 'https://images.dog.ceo/breeds/pug/n02110958_15626.jpg',
+	},
+	{
+		name: 'Angel',
+		breed: 'samoyed',
+		img: 'https://images.dog.ceo/breeds/samoyed/n02111889_4470.jpg',
+	},
 ];

--- a/chapter-3-end/src/data/dogs.js
+++ b/chapter-3-end/src/data/dogs.js
@@ -1,42 +1,42 @@
-export default [
-  {
-    name: 'Max',
-    breed: 'husky',
-    img: 'https://dog.ceo/api/img/husky/n02110185_1469.jpg',
-  },
-  {
-    name: 'Rusty',
-    breed: 'shiba',
-    img: 'https://dog.ceo/api/img/shiba/shiba-13.jpg',
-  },
-  {
-    name: 'Rocco',
-    breed: 'boxer',
-    img: 'https://dog.ceo/api/img/boxer/n02108089_14112.jpg',
-  },
-  {
-    name: 'Zoey',
-    breed: 'beagle',
-    img: 'https://dog.ceo/api/img/beagle/n02088364_11136.jpg',
-  },
-  {
-    name: 'Duke',
-    breed: 'doberman',
-    img: 'https://dog.ceo/api/img/doberman/n02107142_4653.jpg',
-  },
-  {
-    name: 'Lily',
-    breed: 'malamute',
-    img: 'https://dog.ceo/api/img/malamute/n02110063_1104.jpg',
-  },
-  {
-    name: 'Winston',
-    breed: 'pug',
-    img: 'https://dog.ceo/api/img/pug/n02110958_15626.jpg',
-  },
-  {
-    name: 'Angel',
-    breed: 'samoyed',
-    img: 'https://dog.ceo/api/img/samoyed/n02111889_4470.jpg',
-  },
+export const Dogs = [
+	{
+		name: 'Max',
+		breed: 'husky',
+		img: 'https://images.dog.ceo/breeds/husky/n02110185_1469.jpg',
+	},
+	{
+		name: 'Rusty',
+		breed: 'shiba',
+		img: 'https://images.dog.ceo/breeds/shiba/shiba-13.jpg',
+	},
+	{
+		name: 'Rocco',
+		breed: 'boxer',
+		img: 'https://images.dog.ceo/breeds/boxer/n02108089_14112.jpg',
+	},
+	{
+		name: 'Zoey',
+		breed: 'beagle',
+		img: 'https://images.dog.ceo/breeds/beagle/n02088364_11136.jpg',
+	},
+	{
+		name: 'Duke',
+		breed: 'doberman',
+		img: 'https://images.dog.ceo/breeds/doberman/n02107142_4653.jpg',
+	},
+	{
+		name: 'Lily',
+		breed: 'malamute',
+		img: 'https://images.dog.ceo/breeds/malamute/n02110063_1104.jpg',
+	},
+	{
+		name: 'Winston',
+		breed: 'pug',
+		img: 'https://images.dog.ceo/breeds/pug/n02110958_15626.jpg',
+	},
+	{
+		name: 'Angel',
+		breed: 'samoyed',
+		img: 'https://images.dog.ceo/breeds/samoyed/n02111889_4470.jpg',
+	},
 ];

--- a/chapter-4-end/src/data/dogs.js
+++ b/chapter-4-end/src/data/dogs.js
@@ -1,42 +1,42 @@
-export default [
-  {
-    name: 'Max',
-    breed: 'husky',
-    img: 'https://dog.ceo/api/img/husky/n02110185_1469.jpg',
-  },
-  {
-    name: 'Rusty',
-    breed: 'shiba',
-    img: 'https://dog.ceo/api/img/shiba/shiba-13.jpg',
-  },
-  {
-    name: 'Rocco',
-    breed: 'boxer',
-    img: 'https://dog.ceo/api/img/boxer/n02108089_14112.jpg',
-  },
-  {
-    name: 'Zoey',
-    breed: 'beagle',
-    img: 'https://dog.ceo/api/img/beagle/n02088364_11136.jpg',
-  },
-  {
-    name: 'Duke',
-    breed: 'doberman',
-    img: 'https://dog.ceo/api/img/doberman/n02107142_4653.jpg',
-  },
-  {
-    name: 'Lily',
-    breed: 'malamute',
-    img: 'https://dog.ceo/api/img/malamute/n02110063_1104.jpg',
-  },
-  {
-    name: 'Winston',
-    breed: 'pug',
-    img: 'https://dog.ceo/api/img/pug/n02110958_15626.jpg',
-  },
-  {
-    name: 'Angel',
-    breed: 'samoyed',
-    img: 'https://dog.ceo/api/img/samoyed/n02111889_4470.jpg',
-  },
+export const Dogs = [
+	{
+		name: 'Max',
+		breed: 'husky',
+		img: 'https://images.dog.ceo/breeds/husky/n02110185_1469.jpg',
+	},
+	{
+		name: 'Rusty',
+		breed: 'shiba',
+		img: 'https://images.dog.ceo/breeds/shiba/shiba-13.jpg',
+	},
+	{
+		name: 'Rocco',
+		breed: 'boxer',
+		img: 'https://images.dog.ceo/breeds/boxer/n02108089_14112.jpg',
+	},
+	{
+		name: 'Zoey',
+		breed: 'beagle',
+		img: 'https://images.dog.ceo/breeds/beagle/n02088364_11136.jpg',
+	},
+	{
+		name: 'Duke',
+		breed: 'doberman',
+		img: 'https://images.dog.ceo/breeds/doberman/n02107142_4653.jpg',
+	},
+	{
+		name: 'Lily',
+		breed: 'malamute',
+		img: 'https://images.dog.ceo/breeds/malamute/n02110063_1104.jpg',
+	},
+	{
+		name: 'Winston',
+		breed: 'pug',
+		img: 'https://images.dog.ceo/breeds/pug/n02110958_15626.jpg',
+	},
+	{
+		name: 'Angel',
+		breed: 'samoyed',
+		img: 'https://images.dog.ceo/breeds/samoyed/n02111889_4470.jpg',
+	},
 ];

--- a/chapter-5-end/src/data/dogs.js
+++ b/chapter-5-end/src/data/dogs.js
@@ -1,42 +1,42 @@
-export default [
-  {
-    name: 'Max',
-    breed: 'husky',
-    img: 'https://dog.ceo/api/img/husky/n02110185_1469.jpg',
-  },
-  {
-    name: 'Rusty',
-    breed: 'shiba',
-    img: 'https://dog.ceo/api/img/shiba/shiba-13.jpg',
-  },
-  {
-    name: 'Rocco',
-    breed: 'boxer',
-    img: 'https://dog.ceo/api/img/boxer/n02108089_14112.jpg',
-  },
-  {
-    name: 'Zoey',
-    breed: 'beagle',
-    img: 'https://dog.ceo/api/img/beagle/n02088364_11136.jpg',
-  },
-  {
-    name: 'Duke',
-    breed: 'doberman',
-    img: 'https://dog.ceo/api/img/doberman/n02107142_4653.jpg',
-  },
-  {
-    name: 'Lily',
-    breed: 'malamute',
-    img: 'https://dog.ceo/api/img/malamute/n02110063_1104.jpg',
-  },
-  {
-    name: 'Winston',
-    breed: 'pug',
-    img: 'https://dog.ceo/api/img/pug/n02110958_15626.jpg',
-  },
-  {
-    name: 'Angel',
-    breed: 'samoyed',
-    img: 'https://dog.ceo/api/img/samoyed/n02111889_4470.jpg',
-  },
+export const Dogs = [
+	{
+		name: 'Max',
+		breed: 'husky',
+		img: 'https://images.dog.ceo/breeds/husky/n02110185_1469.jpg',
+	},
+	{
+		name: 'Rusty',
+		breed: 'shiba',
+		img: 'https://images.dog.ceo/breeds/shiba/shiba-13.jpg',
+	},
+	{
+		name: 'Rocco',
+		breed: 'boxer',
+		img: 'https://images.dog.ceo/breeds/boxer/n02108089_14112.jpg',
+	},
+	{
+		name: 'Zoey',
+		breed: 'beagle',
+		img: 'https://images.dog.ceo/breeds/beagle/n02088364_11136.jpg',
+	},
+	{
+		name: 'Duke',
+		breed: 'doberman',
+		img: 'https://images.dog.ceo/breeds/doberman/n02107142_4653.jpg',
+	},
+	{
+		name: 'Lily',
+		breed: 'malamute',
+		img: 'https://images.dog.ceo/breeds/malamute/n02110063_1104.jpg',
+	},
+	{
+		name: 'Winston',
+		breed: 'pug',
+		img: 'https://images.dog.ceo/breeds/pug/n02110958_15626.jpg',
+	},
+	{
+		name: 'Angel',
+		breed: 'samoyed',
+		img: 'https://images.dog.ceo/breeds/samoyed/n02111889_4470.jpg',
+	},
 ];


### PR DESCRIPTION
The dog.js array data for the end of chapters 2-and-up contains malformed image URLs.

This was causing some confusion during a workshop when a student got lost and tried to update her code sandbox code from the repo here.

This PR resolves all the image URLs to correct format.