### PR TITLE
Update full-day workshop chapter-end sections with new vuetify

### DIFF
--- a/chapter-1-end/src/main.js
+++ b/chapter-1-end/src/main.js
@@ -1,15 +1,11 @@
 import Vue from 'vue';
-import Vuetify from 'vuetify';
-import 'vuetify/dist/vuetify.min.css';
 import App from './App';
-
-Vue.use(Vuetify);
+import vuetify from "@/plugins/vuetify";
 
 Vue.config.productionTip = false;
 
 /* eslint-disable no-new */
 new Vue({
-  el: '#app',
-  components: { App },
-  template: '<App/>',
-});
+  vuetify,
+  render: h => h(App)
+}).$mount("#app");

--- a/chapter-1-end/src/plugins/vuetify.js
+++ b/chapter-1-end/src/plugins/vuetify.js
@@ -1,0 +1,8 @@
+// src/plugins/vuetify.js
+
+import Vue from "vue";
+import Vuetify from "vuetify";
+import "vuetify/dist/vuetify.min.css";
+Vue.use(Vuetify);
+
+export default new Vuetify();

--- a/chapter-2-end/src/main.js
+++ b/chapter-2-end/src/main.js
@@ -1,11 +1,10 @@
 import Vue from 'vue';
-import Vuetify from 'vuetify';
 import VueRouter from 'vue-router';
 import App from './App';
+import vuetify from "@/plugins/vuetify";
 import Home from './views/Home';
 import Pets from './views/Pets';
 
-Vue.use(Vuetify);
 Vue.use(VueRouter);
 
 Vue.config.productionTip = false;
@@ -19,8 +18,7 @@ const router = new VueRouter({ routes });
 
 /* eslint-disable no-new */
 new Vue({
-  el: '#app',
-  components: { App },
-  template: '<App/>',
+  vuetify,
   router,
-});
+  render: h => h(App)
+}).$mount("#app");

--- a/chapter-2-end/src/plugins/vuetify.js
+++ b/chapter-2-end/src/plugins/vuetify.js
@@ -1,0 +1,8 @@
+// src/plugins/vuetify.js
+
+import Vue from "vue";
+import Vuetify from "vuetify";
+import "vuetify/dist/vuetify.min.css";
+Vue.use(Vuetify);
+
+export default new Vuetify();

--- a/chapter-3-end/src/main.js
+++ b/chapter-3-end/src/main.js
@@ -1,12 +1,10 @@
 import Vue from 'vue';
-import Vuetify from 'vuetify';
-import 'vuetify/dist/vuetify.min.css';
 import VueRouter from 'vue-router';
 import App from './App';
+import vuetify from "@/plugins/vuetify";
 import Home from './views/Home';
 import Pets from './views/Pets';
 
-Vue.use(Vuetify);
 Vue.use(VueRouter);
 
 Vue.config.productionTip = false;
@@ -20,8 +18,7 @@ const router = new VueRouter({ routes });
 
 /* eslint-disable no-new */
 new Vue({
-  el: '#app',
-  components: { App },
-  template: '<App/>',
+  vuetify,
   router,
-});
+  render: h => h(App)
+}).$mount("#app");

--- a/chapter-3-end/src/plugins/vuetify.js
+++ b/chapter-3-end/src/plugins/vuetify.js
@@ -1,0 +1,8 @@
+// src/plugins/vuetify.js
+
+import Vue from "vue";
+import Vuetify from "vuetify";
+import "vuetify/dist/vuetify.min.css";
+Vue.use(Vuetify);
+
+export default new Vuetify();

--- a/chapter-4-end/src/main.js
+++ b/chapter-4-end/src/main.js
@@ -1,14 +1,12 @@
 import Vue from 'vue';
-import Vuetify from 'vuetify';
-import 'vuetify/dist/vuetify.min.css';
 import VueRouter from 'vue-router';
 import App from './App';
+import vuetify from "@/plugins/vuetify";
 import Home from './views/Home';
 import Pets from './views/Pets';
 import Favorites from './views/Favorites';
 import store from './store/store';
 
-Vue.use(Vuetify);
 Vue.use(VueRouter);
 
 Vue.config.productionTip = false;
@@ -23,9 +21,8 @@ const router = new VueRouter({ routes });
 
 /* eslint-disable no-new */
 new Vue({
-  el: '#app',
-  components: { App },
-  template: '<App/>',
+  vuetify,
   router,
   store,
-});
+  render: h => h(App)
+}).$mount("#app");

--- a/chapter-4-end/src/plugins/vuetify.js
+++ b/chapter-4-end/src/plugins/vuetify.js
@@ -1,0 +1,8 @@
+// src/plugins/vuetify.js
+
+import Vue from "vue";
+import Vuetify from "vuetify";
+import "vuetify/dist/vuetify.min.css";
+Vue.use(Vuetify);
+
+export default new Vuetify();

--- a/chapter-5-end/src/main.js
+++ b/chapter-5-end/src/main.js
@@ -1,15 +1,13 @@
 import Vue from 'vue';
-import Vuetify from 'vuetify';
-import 'vuetify/dist/vuetify.min.css';
 import VueRouter from 'vue-router';
 import App from './App';
+import vuetify from "@/plugins/vuetify";
 import Home from './views/Home';
 import Pets from './views/Pets';
 import Favorites from './views/Favorites';
 import Form from './views/Form';
 import store from './store/store';
 
-Vue.use(Vuetify);
 Vue.use(VueRouter);
 
 Vue.config.productionTip = false;
@@ -25,9 +23,8 @@ const router = new VueRouter({ routes });
 
 /* eslint-disable no-new */
 new Vue({
-  el: '#app',
-  components: { App },
-  template: '<App/>',
+  vuetify,
   router,
   store,
-});
+  render: h => h(App)
+}).$mount("#app");

--- a/chapter-5-end/src/plugins/vuetify.js
+++ b/chapter-5-end/src/plugins/vuetify.js
@@ -1,0 +1,8 @@
+// src/plugins/vuetify.js
+
+import Vue from "vue";
+import Vuetify from "vuetify";
+import "vuetify/dist/vuetify.min.css";
+Vue.use(Vuetify);
+
+export default new Vuetify();


### PR DESCRIPTION
With the latest Vue and Vuetify dependency installations within Codesandbox, we need to update the way Vuetify is used in the full-day workshop so it's less confusing for students.

The PR for workshop instructions update is here: https://github.com/VueVixens/docs/pull/86

This PR changes the chapter-end code to match the new Vuetify usage and the default Vue initializer blocks which have a syntax update in codesandbox.